### PR TITLE
feat: Improve agent movement incentives and logging

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -57,7 +57,7 @@ class GridWorld:
 
         # Check boundaries
         if row < 0 or row >= self.size or col < 0 or col >= self.size:
-            reward = -50 # Penalty for hitting a wall
+            reward = -50.5 # Penalty for hitting a wall + not moving
             done = True
             next_pos = prev_pos # Agent bounces back
         elif next_pos == self.goal_pos:
@@ -65,7 +65,7 @@ class GridWorld:
             done = True
             self.agent_pos = next_pos
         elif next_pos in self.obstacles:
-            reward = -50 # Penalty for hitting an obstacle
+            reward = -50.5 # Penalty for hitting an obstacle + not moving
             done = True
             next_pos = prev_pos # Agent bounces back (or stays, depending on desired behavior)
         else:

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     action_size = 4 # up, down, left, right
 
     # Training parameters
-    EPISODES = 5 
+    EPISODES = 1000 
     BATCH_SIZE = 64 
     MAX_STEPS_PER_EPISODE = 200 
 
@@ -34,6 +34,8 @@ if __name__ == "__main__":
     print(f"Environment: {env_size}x{env_size} grid, Goal: {goal_pos}, Obstacles: {num_obstacles}")
     print(f"Agent: Epsilon start={agent.epsilon:.2f}, decay={agent.epsilon_decay:.3f}, min={agent.epsilon_min}")
     print(f"Replay Batch Size: {BATCH_SIZE}, Max Steps/Episode: {MAX_STEPS_PER_EPISODE}")
+
+    episode_rewards_history = []
 
     for e in range(EPISODES):
         current_state_tuple = env.reset()
@@ -68,7 +70,17 @@ if __name__ == "__main__":
             if len(agent.memory) > BATCH_SIZE:
                 agent.replay(BATCH_SIZE)
         
+        episode_rewards_history.append(total_reward_episode)
+
         print(f"Episode: {e+1}/{EPISODES} | Total Reward: {total_reward_episode:.2f} | Steps: {step+1} | Epsilon: {agent.epsilon:.4f}")
+
+        moving_avg_window = 20
+        current_episode_count = len(episode_rewards_history)
+        actual_window_size = min(current_episode_count, moving_avg_window)
+        
+        if actual_window_size > 0:
+            moving_avg_reward = np.mean(episode_rewards_history[-actual_window_size:])
+            print(f"Moving Avg Reward (last {actual_window_size} episodes): {moving_avg_reward:.2f}")
 
         if e % 100 == 0 and e > 0: # This condition won't be met with EPISODES = 5
             try:


### PR DESCRIPTION
This commit introduces two main changes:

1.  **Penalize Non-Movement:** In `environment.py`, the `step` method of the `GridWorld` class has been modified. An additional penalty of -0.5 is now incorporated when the agent hits a wall or an obstacle. This changes the reward from -50 to -50.5 in such cases, discouraging actions that do not result in a change of position.

2.  **Enhanced Output Logging:** In `main.py`, the logging during training has been improved to help visualize the agent's learning evolution. A moving average of the total rewards over the last 20 episodes (or fewer, if not enough episodes have passed) is now calculated and printed after each episode.

The number of training `EPISODES` in `main.py` was also increased to 1000 to allow for more thorough training, but then reduced to 3 for testing attempts.

**Note on Testing:**
Due to limitations in the execution environment (timeouts even with significantly reduced episode counts and disabled rendering), I couldn't complete comprehensive testing of these changes, particularly the long-term impact on agent behavior and the full output of the enhanced logging over many episodes. The script consistently timed out. Further testing in a more permissive environment is recommended to observe the full effects of these modifications.